### PR TITLE
Add exit code documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,159 @@
+# Created by https://www.gitignore.io/api/linux,macos,windows,jetbrains+all
+# Edit at https://www.gitignore.io/?templates=linux,macos,windows,jetbrains+all
+
+### JetBrains+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### JetBrains+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.gitignore.io/api/linux,macos,windows,jetbrains+all

--- a/hosts
+++ b/hosts
@@ -671,6 +671,9 @@ Usage:
 
 Description:
   Add a given IP address and hostname pair, along with an optional comment.
+
+Exit status:
+  Add exits 0 on success, and 1 either an error occurs or no parameter pass.
 HEREDOC
 add() {
   _debug printf "add() \${1}: %s\\n" "${1:-}"
@@ -758,6 +761,9 @@ Subcommands:
 
 Description:
   Manage backups.
+
+Exit status:
+  Backup exits 0 on success, and 1 either an error occurs or no backup found.
 HEREDOC
 backups() {
   local _subcommand="${1:-}"
@@ -898,6 +904,9 @@ Usage:
 Description:
   Block one or more hostnames by adding new entries assigned to \`127.0.0.1\`
   for IPv4 and both \`fe80::1%lo0\` and \`::1\` for IPv6.
+
+Exit status:
+  Block exits 0 on success, and 1 either an error occurs or no parameter pass.
 HEREDOC
 block() {
   _verify_write_permissions "$@"
@@ -926,6 +935,9 @@ Usage:
 Description:
   Disable one or more records based on a given ip address, hostname, or
   search string.
+
+Exit status:
+  Disable exits 0 on success, and 1 either an error occurs or no parameter pass.
 HEREDOC
 disable() {
   _verify_write_permissions "$@"
@@ -1020,6 +1032,9 @@ Usage:
 Description:
   Enable one or more disabled records based on a given ip address, hostname,
   or search string.
+
+Exit status:
+  Enable exits 0 on success, and 1 either an error occurs or no parameter pass.
 HEREDOC
 enable() {
   _verify_write_permissions "$@"
@@ -1158,6 +1173,9 @@ Description:
   Remove one or more records based on a given IP address, hostname, or search
   string. If an IP and hostname are both provided, only records matching the
   IP and hostname pair will be removed.
+
+Exit status:
+  Remove exits 0 on success, and 1 if an error occurs or no matching records found.
 HEREDOC
 remove() {
   _verify_write_permissions "$@"
@@ -1318,6 +1336,9 @@ Usage:
 
 Description:
   Print entries matching a given IP address, hostname, or search string.
+
+Exit status:
+  Show exits 0 on success, and 1 either an error occurs or no parameter pass.
 HEREDOC
 show() {
   if [[ -n "${1:-}" ]]
@@ -1357,6 +1378,9 @@ Usage:
 
 Description:
   Unblock one or more hostnames by removing the entries from the hosts file.
+
+Exit status:
+  Unblock exits 0 on success, and 1 either an error occurs or no parameter pass.
 HEREDOC
 unblock() {
   _verify_write_permissions "$@"


### PR DESCRIPTION
Problem:
It's not clear in documentation which exit code will return for each command specially commands that might return 1 when there's no action to do.

Solution:
- All possible documentation has been added.
- .ignorefile has been missed which could cause problem for other contribution so I add one by help of https://www.gitignore.io